### PR TITLE
Remove appeal fields for some jurisdictions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
-    rev: '21.7b0' # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: '22.3.0' # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         exclude: ^.*\b(migrations)\b.*$

--- a/froide_legalaction/forms.py
+++ b/froide_legalaction/forms.py
@@ -151,16 +151,19 @@ class LegalActionRequestForm(LegalActionUserForm):
         return ["foimessage_%s" % kind]
 
     def add_document_fields(self, kind, kind_detail):
+        required = kind_detail["required"]
         self.fields["date_%s" % kind] = forms.DateField(
             label=_("Date of {}").format(kind_detail["label"]),
             validators=[validators.MaxValueValidator(timezone.now().date())],
             widget=forms.DateInput(attrs={"type": "date", "class": "form-control"}),
+            required=required,
         )
         self.fields["document_%s" % kind] = forms.FileField(
             label=_("Upload document for {}").format(kind_detail["label"]),
             help_text=kind_detail["help_text_upload"],
             validators=[validate_upload_document],
             widget=forms.FileInput(attrs={"class": "form-control"}),
+            required=required,
         )
         return ["date_%s" % kind, "document_%s" % kind]
 

--- a/froide_legalaction/forms.py
+++ b/froide_legalaction/forms.py
@@ -135,20 +135,6 @@ class LegalActionRequestForm(LegalActionUserForm):
             + ["legal_date", "description"]
         )
 
-    def appeal_allowed(self, foirequest):
-        jurisdictions_not_allowed = ["nrw", "bayern"]
-        if foirequest:
-            return (
-                foirequest.public_body.jurisdiction.slug
-                not in jurisdictions_not_allowed
-            )
-        return True
-
-    def should_field_be_added(self, document_kind):
-        if document_kind in ["appeal", "final_rejection"]:
-            return self.appeal_allowed(self.foirequest)
-        return True
-
     def add_foimessage_fields(self, kind, kind_detail):
         required = kind_detail["required"]
         qs, mes = self.foimessage_qs, self.first_foimessage

--- a/froide_legalaction/models/lawsuit_models.py
+++ b/froide_legalaction/models/lawsuit_models.py
@@ -220,6 +220,7 @@ class ProposalDocument(models.Model):
                 "select": lambda qs, first: qs.filter(pk=first.pk),
                 "hidden": True,
                 "initial": lambda qs, first: first,
+                "required": True,
             },
         ),
         (
@@ -230,6 +231,7 @@ class ProposalDocument(models.Model):
                 "help_text": _("Please select the rejection response."),
                 "select": lambda qs, first: qs.filter(is_response=True),
                 "initial": None,
+                "required": True,
             },
         ),
         (
@@ -246,6 +248,7 @@ class ProposalDocument(models.Model):
                     is_response=False, timestamp__gt=first.timestamp
                 ),
                 "initial": None,
+                "required": False,
             },
         ),
         (
@@ -261,6 +264,7 @@ class ProposalDocument(models.Model):
                 ),
                 "select": lambda qs, first: qs.filter(is_response=True),
                 "initial": None,
+                "required": False,
             },
         ),
     )


### PR DESCRIPTION
Solves the problem that not for all foi requests a 'widerspruch' is present (eg. in NRW or Bayern) but documents concerning the widerspruch need to be uploaded when proposing a lawsuit. This PR makes the fields for those documents not required.